### PR TITLE
binary sensor typeの判定に"open/close"の値も許容する

### DIFF
--- a/src/payload/readonly/binary_sensor.ts
+++ b/src/payload/readonly/binary_sensor.ts
@@ -1,5 +1,5 @@
 import type { Payload } from "@/payload/payloadType";
-import { isBooleanType } from "@/util/deviceUtil";
+import { isBooleanType, isElStateType } from "@/util/deviceUtil";
 import assert from "assert";
 import type {
   ApiDevice,
@@ -11,7 +11,13 @@ export default function buildBinarySensor(
   property: ApiDeviceProperty,
 ): Payload {
   const { data } = property.schema;
-  assert(isBooleanType(data));
+  assert(
+    isBooleanType(data) ||
+      (isElStateType(data) &&
+        data.enum.length === 2 &&
+        data.enum[0].name === "open"),
+    `Property ${property.name} is not a valid binary sensor type`,
+  );
 
   const [on, off] = data.enum;
   const deviceClass = getDeviceClass(apiDevice, property);


### PR DESCRIPTION
#### 概要

  buildBinarySensor関数で"open"/"close"状態のプロパティを受け入れるようにassert条件を修正しました。

#### 問題

getSimpleComponent関数では、以下の条件でプロパティをbinary_sensorとして分類されています：
  - isBooleanType(data) ("true"/"false"の状態)
  - isElStateType(data) && data.enum[0].name === "open" ("open"/"close"の状態)

しかし、buildBinarySensor関数ではisBooleanType(data)のみをチェックしていたため、"open"/"close"状態のプロパティでアサーションエラーが発生していました。

#### 発見の経緯

自宅のEOJ 03bb（炊飯器で登録されている、実際にはホットクック）の蓋開閉状態（EPC 0xB0）が"open"/"close"として定義されており、実行時に以下のエラーが発生することで問題に気づきました：
```
  AssertionError [ERR_ASSERTION]: false == true
      at buildBinarySensor (/path/to/binary_sensor.ts:14:3)
```

#### 解決方法

buildBinarySensorのassert条件をgetSimpleComponentの分類ロジックと一致させました：

  - "true"/"false"状態（isBooleanType）
  - "open"/"close"状態（2つのenumを持ち、最初が"open"）

両方の状態タイプを受け入れるように修正しています。