### PR TITLE
fix: resolve circular dependency in MQTT client initialization

### DIFF
--- a/src/manager/mqttDeviceManager.ts
+++ b/src/manager/mqttDeviceManager.ts
@@ -90,10 +90,8 @@ export default async function setupMqttDeviceManager(
     }
   };
 
-  const mqtt = await initializeMqttClient(
-    [env.ECHONETLITE2MQTT_BASE_TOPIC],
-    handleMessage,
-  );
+  const mqtt = await initializeMqttClient([env.ECHONETLITE2MQTT_BASE_TOPIC]);
+  mqtt.setMessageHandler(handleMessage);
 
   // 更新通知をしないプロパティに対して、定期的に自動リクエストする
   let isAutoRequestRunning = true;

--- a/src/manager/mqttDeviceManager.ts
+++ b/src/manager/mqttDeviceManager.ts
@@ -22,6 +22,9 @@ export default async function setupMqttDeviceManager(
   const origin = buildOrigin();
 
   const subscribeDeviceTopics = new Set<string>();
+
+  const mqtt = await initializeMqttClient([env.ECHONETLITE2MQTT_BASE_TOPIC]);
+
   const handleDeviceList = (apiDeviceSummaries: ApiDeviceSummary[]) => {
     logger.info("[MQTT] handleDeviceList");
     apiDeviceSummaries.forEach(({ deviceType, mqttTopics }) => {
@@ -90,7 +93,6 @@ export default async function setupMqttDeviceManager(
     }
   };
 
-  const mqtt = await initializeMqttClient([env.ECHONETLITE2MQTT_BASE_TOPIC]);
   mqtt.setMessageHandler(handleMessage);
 
   // 更新通知をしないプロパティに対して、定期的に自動リクエストする

--- a/tests/manager/mqttDeviceManager.spec.ts
+++ b/tests/manager/mqttDeviceManager.spec.ts
@@ -40,6 +40,7 @@ describe("setupMqttDeviceManager", () => {
     taskQueueSize: 0,
     addSubscribe: vi.fn(),
     close: vi.fn(),
+    setMessageHandler: vi.fn(),
   };
 
   beforeEach(() => {
@@ -69,10 +70,9 @@ describe("setupMqttDeviceManager", () => {
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
     await stopAutoRequest();
 
-    expect(initializeMqttClient).toHaveBeenCalledWith(
-      [env.ECHONETLITE2MQTT_BASE_TOPIC],
-      expect.any(Function),
-    );
+    expect(initializeMqttClient).toHaveBeenCalledWith([
+      env.ECHONETLITE2MQTT_BASE_TOPIC,
+    ]);
   });
 
   test("デバイスリストを処理し、新しいトピックを購読する", async () => {
@@ -83,12 +83,16 @@ describe("setupMqttDeviceManager", () => {
     ] as ApiDeviceSummary[];
 
     const handleMessage = vi.fn();
-    vi.mocked(initializeMqttClient).mockImplementation(
-      (_subscribeTopics, handler: (topic: string, message: string) => void) => {
-        handleMessage.mockImplementation(handler);
-        return Promise.resolve(mockMqttClient);
-      },
-    );
+    vi.mocked(initializeMqttClient).mockImplementation(() => {
+      return Promise.resolve({
+        ...mockMqttClient,
+        setMessageHandler: (
+          handler: (topic: string, message: string) => void,
+        ) => {
+          handleMessage.mockImplementation(handler);
+        },
+      });
+    });
 
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
     await stopAutoRequest();
@@ -116,7 +120,9 @@ describe("setupMqttDeviceManager", () => {
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
     await stopAutoRequest();
 
-    const handleMessage = vi.mocked(initializeMqttClient).mock.calls[0][1];
+    const setMessageHandlerCall = vi.mocked(mockMqttClient.setMessageHandler)
+      .mock.calls[0];
+    const handleMessage = setMessageHandlerCall[0];
 
     await handleMessage(
       env.ECHONETLITE2MQTT_BASE_TOPIC,
@@ -152,12 +158,16 @@ describe("setupMqttDeviceManager", () => {
   test("未知のトピックは無視する", async () => {
     const targetDevices = new Map<string, ApiDevice>();
     const handleMessage = vi.fn();
-    vi.mocked(initializeMqttClient).mockImplementation(
-      (_subscribeTopics, handler: (topic: string, message: string) => void) => {
-        handleMessage.mockImplementation(handler);
-        return Promise.resolve(mockMqttClient);
-      },
-    );
+    vi.mocked(initializeMqttClient).mockImplementation(() => {
+      return Promise.resolve({
+        ...mockMqttClient,
+        setMessageHandler: (
+          handler: (topic: string, message: string) => void,
+        ) => {
+          handleMessage.mockImplementation(handler);
+        },
+      });
+    });
 
     const logErrorSpy = vi.spyOn(logger, "error");
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
@@ -177,12 +187,16 @@ describe("setupMqttDeviceManager", () => {
     ] as ApiDeviceSummary[];
 
     const handleMessage = vi.fn();
-    vi.mocked(initializeMqttClient).mockImplementation(
-      (_subscribeTopics, handler: (topic: string, message: string) => void) => {
-        handleMessage.mockImplementation(handler);
-        return Promise.resolve(mockMqttClient);
-      },
-    );
+    vi.mocked(initializeMqttClient).mockImplementation(() => {
+      return Promise.resolve({
+        ...mockMqttClient,
+        setMessageHandler: (
+          handler: (topic: string, message: string) => void,
+        ) => {
+          handleMessage.mockImplementation(handler);
+        },
+      });
+    });
 
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
     await stopAutoRequest();

--- a/tests/service/mqtt.spec.ts
+++ b/tests/service/mqtt.spec.ts
@@ -34,7 +34,8 @@ beforeEach(() => {
 
 describe("initializeMqttClient", () => {
   test("MQTTクライアントが正常に接続される", async () => {
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     await mqtt.close();
 
@@ -57,7 +58,8 @@ describe("initializeMqttClient", () => {
   test("メッセージを受信するとhandleMessageが呼ばれる", async () => {
     const mockPayload = Buffer.from("test message");
 
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     // メッセージイベントをトリガー
     const onMessageCallback = mockOn.mock.calls.find(
@@ -81,7 +83,8 @@ describe("initializeMqttClient", () => {
       throw new Error("test error");
     });
 
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     const onMessageCallback = mockOn.mock.calls.find(
       ([event]) => event === "message",
@@ -102,7 +105,8 @@ describe("initializeMqttClient", () => {
       Promise.reject(new Error("test error")),
     );
 
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     const onMessageCallback = mockOn.mock.calls.find(
       ([event]) => event === "message",
@@ -117,7 +121,8 @@ describe("initializeMqttClient", () => {
   });
 
   test("publishがタスクキューに追加される", async () => {
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     // publishを呼び出す
     mqtt.publish("topic/publish", "test message", { retain: true });
@@ -129,7 +134,7 @@ describe("initializeMqttClient", () => {
   });
 
   test("addSubscribeがタスクキューに追加される", async () => {
-    const mqtt = await initializeMqttClient(["topic/test"], () => {});
+    const mqtt = await initializeMqttClient(["topic/test"]);
 
     // addSubscribeを呼び出す
     mqtt.addSubscribe("topic/new");
@@ -146,7 +151,7 @@ describe("initializeMqttClient", () => {
       return Promise.resolve();
     });
 
-    const mqtt = await initializeMqttClient(["topic/test"], () => {});
+    const mqtt = await initializeMqttClient(["topic/test"]);
 
     mqtt.publish("topic", "message");
 
@@ -166,7 +171,8 @@ describe("initializeMqttClient", () => {
       return Promise.resolve();
     });
 
-    const mqtt = await initializeMqttClient(["topic/test"], mockHandleMessage);
+    const mqtt = await initializeMqttClient(["topic/test"]);
+    mqtt.setMessageHandler(mockHandleMessage);
 
     mqtt.publish("topic", "message");
 


### PR DESCRIPTION
#### 概要

mqttDeviceManagerで発生するMQTT変数の初期化エラーを修正しました。

#### 現象

アプリケーション実行時に以下のエラーが発生していました（状況によっては問題ない時もありました）：

```
% npm run dev --env-file=.env

> e2m-hass-bridge@1.10.0 dev
> tsx --env-file=.env src/index.ts

[2025-08-03 17:21:49.829] [info]: start
[2025-08-03 17:21:51.375] [info]: [MQTT] connected
[2025-08-03 17:21:51.385] [info]: [MQTT] handleDeviceList
[2025-08-03 17:21:51.389] [error]: [MQTT] message error: Cannot access 'mqtt' before initialization
ReferenceError: Cannot access 'mqtt' before initialization
    at <anonymous> (/PATH_TO_REPO/src/manager/mqttDeviceManager.ts:36:7)
    at Array.forEach (<anonymous>)
    at handleDeviceList (/PATH_TO_REPO/src/manager/mqttDeviceManager.ts:27:24)
    at handleMessage (/PATH_TO_REPO/src/manager/mqttDeviceManager.ts:83:7)
    at MqttClient.<anonymous> (/PATH_TO_REPO/src/service/mqtt.ts:33:22)
    at MqttClient.emit (node:events:507:28)
    at handlePublish (/PATH_TO_REPO/node_modules/mqtt/src/lib/handlers/publish.ts:172:11)
    at handle (/PATH_TO_REPO/node_modules/mqtt/src/lib/handlers/index.ts:31:17)
    at work (/PATH_TO_REPO/node_modules/mqtt/src/lib/client.ts:793:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:85:11)
[2025-08-03 17:21:51.389] [info]: Starting auto request...
[2025-08-03 17:21:51.402] [info]: [HTTP] listen port: 4000
[2025-08-03 17:21:51.402] [info]: ready
[2025-08-03 17:24:51.394] [info]: Starting auto request...
[2025-08-03 17:27:51.399] [info]: Starting auto request...
```

#### 問題

[mqttDeviceManager.ts](https://github.com/nana4rider/e2m-hass-bridge/blob/a90556e0be84ae6a9587b02d10bc03ea8d1ef553/src/manager/mqttDeviceManager.ts) 内に、以下のような箇所があります。

```typescript
const handleDeviceList = (apiDeviceSummaries) => {
  mqtt.addSubscribe(mqttTopics); // ← mqttが必要
};

const handleMessage = (topic, message) => {
  handleDeviceList(parseJson(message)); // ← handleDeviceListを呼ぶ
};

const mqtt = await initializeMqttClient([...], handleMessage); // ← handleMessageが必要
```

initializeMqttClientの最中にMQTTメッセージを受信してしまうと、handleMessageが呼ばれmqttを参照します。

#### 変更内容

mqtt.tsの [initializeMqttClient](https://github.com/nana4rider/e2m-hass-bridge/blob/a90556e0be84ae6a9587b02d10bc03ea8d1ef553/src/service/mqtt.ts#L19)からhandleMessage引数をなくし、setMessageHandlerで後からハンドラを設定するようにしました。

1. `initializeMqttClient`の`handleMessage`パラメータを削除
  - `handleMessage?: (topic: string, message: string) => void | Promise<void>,` として残してもよいかもしれません
3. `setMessageHandler`メソッドを追加して初期化後にハンドラを設定
4. 関連するテストコードの更新

#### 結果

```
% npm run dev --env-file=.env

> e2m-hass-bridge@1.10.0 dev
> tsx --env-file=.env src/index.ts

[2025-08-03 17:32:48.357] [info]: start
[2025-08-03 17:32:49.716] [info]: [MQTT] connected
[2025-08-03 17:32:49.727] [info]: Starting auto request...
[2025-08-03 17:32:49.745] [info]: [HTTP] listen port: 4000
[2025-08-03 17:32:49.746] [info]: ready
[2025-08-03 17:32:49.746] [info]: [MQTT] handleDeviceList
[2025-08-03 17:32:49.856] [info]: handleDevice: fe0000......
[2025-08-03 17:32:49.953] [info]: handleDevice: fe0000......
[2025-08-03 17:32:50.061] [info]: handleDevice: fe0000......
.
.
[2025-08-03 17:35:49.731] [info]: Starting auto request...
[2025-08-03 17:38:49.736] [info]: Starting auto request...
```