### PR TITLE
起動時にretain messageを処理しないことがある

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "e2m-hass-bridge",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "e2m-hass-bridge",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "ISC",
       "dependencies": {
         "envalid": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2m-hass-bridge",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": "nana4rider",
   "license": "ISC",
   "main": "dist/index.js",

--- a/src/manager/mqttDeviceManager.ts
+++ b/src/manager/mqttDeviceManager.ts
@@ -23,7 +23,7 @@ export default async function setupMqttDeviceManager(
 
   const subscribeDeviceTopics = new Set<string>();
 
-  const mqtt = await initializeMqttClient([env.ECHONETLITE2MQTT_BASE_TOPIC]);
+  const mqtt = await initializeMqttClient();
 
   const handleDeviceList = (apiDeviceSummaries: ApiDeviceSummary[]) => {
     logger.info("[MQTT] handleDeviceList");
@@ -94,6 +94,8 @@ export default async function setupMqttDeviceManager(
   };
 
   mqtt.setMessageHandler(handleMessage);
+
+  mqtt.addSubscribe(env.ECHONETLITE2MQTT_BASE_TOPIC);
 
   // 更新通知をしないプロパティに対して、定期的に自動リクエストする
   let isAutoRequestRunning = true;

--- a/src/service/mqtt.ts
+++ b/src/service/mqtt.ts
@@ -19,9 +19,7 @@ export type MqttClient = {
   ) => void;
 };
 
-export default async function initializeMqttClient(
-  subscribeTopics: string[],
-): Promise<MqttClient> {
+export default async function initializeMqttClient(): Promise<MqttClient> {
   const client = await mqttjs.connectAsync(env.MQTT_BROKER, {
     clientId: `${packageName}_${randomBytes(4).toString("hex")}`,
     username: env.MQTT_USERNAME,
@@ -60,12 +58,6 @@ export default async function initializeMqttClient(
   };
 
   logger.info("[MQTT] connected");
-
-  await client.subscribeAsync(subscribeTopics);
-
-  for (const topic of subscribeTopics) {
-    logger.debug(`[MQTT] subscribe topic: ${topic}`);
-  }
 
   let isMqttTaskRunning = true;
   const mqttTask = (async () => {
@@ -107,6 +99,7 @@ export default async function initializeMqttClient(
 
   const addSubscribe = (topic: string): void => {
     taskQueue.push(async () => {
+      logger.debug(`[MQTT] subscribe topic: ${topic}`);
       await client.subscribeAsync(topic);
     });
   };

--- a/tests/manager/mqttDeviceManager.spec.ts
+++ b/tests/manager/mqttDeviceManager.spec.ts
@@ -70,9 +70,9 @@ describe("setupMqttDeviceManager", () => {
     const { stopAutoRequest } = await setupMqttDeviceManager(targetDevices);
     await stopAutoRequest();
 
-    expect(initializeMqttClient).toHaveBeenCalledWith([
+    expect(mockMqttClient.addSubscribe).toHaveBeenCalledWith(
       env.ECHONETLITE2MQTT_BASE_TOPIC,
-    ]);
+    );
   });
 
   test("デバイスリストを処理し、新しいトピックを購読する", async () => {


### PR DESCRIPTION
`setMessageHandler`でイベントハンドラが設定される前にretain messageを読み込むことがあり、起動時にデバイスリストの読み込みをしないことがある。
https://github.com/nana4rider/e2m-hass-bridge/pull/8#issuecomment-3148401570

`setMessageHandler`を実装して頂いたことで初期化と同時にsubscribeする必要がなくなったので、`initializeMqttClient`の引数を廃止し、`addSubscribe`を利用するように修正した。